### PR TITLE
fix 2 bugs with Mojolicious integration

### DIFF
--- a/lib/Mojolicious/Plugin/SentrySDK.pm
+++ b/lib/Mojolicious/Plugin/SentrySDK.pm
@@ -13,7 +13,7 @@ sub register ($self, $app, $conf) {
 
   $app->hook(
     around_action => sub ($next, $c, $action, $last) {
-      return unless $last;
+      return $next->() unless $last;
 
       my $req = $c->req;
 

--- a/lib/Sentry/Integration/MojoUserAgent.pm
+++ b/lib/Sentry/Integration/MojoUserAgent.pm
@@ -50,7 +50,7 @@ sub setup_once ($self, $add_global_event_processor, $get_current_hub) {
       })
         if $self->breadcrumbs;
 
-      if ($self->tracing) {
+      if ($span) {
         $span->set_http_status($tx->res->code);
         $span->finish();
       }


### PR DESCRIPTION
  * in the plugin, the around_action hook does not call $next->() on an
    intermediate route. That breaks the dispatch chain
  * in the UA integration, $span can be used w/o being set
