### PR TITLE
Add support for reporting child spans to Sentry

### DIFF
--- a/lib/Sentry/Tracing/Span.pm
+++ b/lib/Sentry/Tracing/Span.pm
@@ -126,4 +126,9 @@ sub finish ($self) {
   $self->timestamp(time);
 }
 
+sub _collect_spans ($self) {
+  my @spans = map { ($_, $_->_collect_spans()->@*) } $self->spans->@*;
+  return \@spans || [];
+}
+
 1;

--- a/lib/Sentry/Tracing/Transaction.pm
+++ b/lib/Sentry/Tracing/Transaction.pm
@@ -19,7 +19,7 @@ sub finish ($self) {
 
   my %transaction = (
     contexts        => { trace => $self->get_trace_context(), },
-    spans           => $self->spans,
+    spans           => $self->_collect_spans(),
     start_timestamp => $self->start_timestamp,
     tags            => $self->tags,
     timestamp       => $self->timestamp,


### PR DESCRIPTION
The API expects all spans in a single array with the transaction. This PR recursively collects them all and submits them as part of the transaction