### PR TITLE
Fix transaction name with nested routes in Mojo

### DIFF
--- a/lib/Mojolicious/Plugin/SentrySDK.pm
+++ b/lib/Mojolicious/Plugin/SentrySDK.pm
@@ -21,7 +21,7 @@ sub register ($self, $app, $conf) {
         my %cookies = map { ($_->name, $_->value) } ($req->cookies // [])->@*;
         my $transaction = Sentry::SDK->start_transaction(
           {
-            name    => $c->match->endpoint->pattern->unparsed || '/',
+            name    => $c->match->endpoint->to_string || '/',
             op      => 'http.server',
             request => {
               url          => $req->url->to_abs->to_string,


### PR DESCRIPTION
`endpoint->pattern->unparsed` only gets the pattern of last route in a nested route chain. `endpoint->to_string` combines the unparsed patterns of all routes in the chain.