### PR TITLE
Fix `capture_context` for `capture_exception`. Add to `capture_event`

### DIFF
--- a/lib/Sentry/Hub/Scope.pm
+++ b/lib/Sentry/Hub/Scope.pm
@@ -156,7 +156,11 @@ sub clone ($self) {
 }
 
 sub update ($self, $fields) {
-  $self->$_($fields->{$_}) for keys $fields->%*;
+  for (keys $fields->%*) {
+    my $methodName = "set_$_";
+    $self->$methodName($fields->{$_});
+  }
+  return $self;
 }
 
 sub get_global_event_processors () {

--- a/lib/Sentry/SDK.pm
+++ b/lib/Sentry/SDK.pm
@@ -48,12 +48,14 @@ sub capture_message ($self, $message, $capture_context = undef) {
     { capture_context => ref($capture_context) ? $capture_context : undef, });
 }
 
-sub capture_event ($package, $event) {
-  _call_on_hub('capture_event', $event);
+sub capture_event ($package, $event, $capture_context = undef) {
+  _call_on_hub('capture_event', $event,
+    { capture_context => ref($capture_context) ? $capture_context : undef, });
 }
 
 sub capture_exception ($package, $exception, $capture_context = undef) {
-  _call_on_hub('capture_exception', $exception, $capture_context);
+  _call_on_hub('capture_exception', $exception, 
+    { capture_context => ref($capture_context) ? $capture_context : undef, });
 }
 
 sub configure_scope ($package, $cb) {

--- a/t/sdk.t
+++ b/t/sdk.t
@@ -88,22 +88,26 @@ describe 'Sentry::SDK' => sub {
 
     it 'capture_event()' => sub {
       my $event = { foo => 'bar' };
-      Sentry::SDK->capture_event($event);
+      my $context = { level => Sentry::Severity->Error };
+      Sentry::SDK->capture_event($event, $context);
 
       my $captured = $client->_captured_message;
       isa_ok $captured->{scope}, 'Sentry::Hub::Scope';
       is_deeply $captured->{event}, $event;
+      is_deeply $captured->{hint}{capture_context}, $context;
       is_UUID_string $captured->{hint}{event_id};
     };
 
     it 'capture_exception()' => sub {
       my $exception = Mojo::Exception->new('ohoh');
-      Sentry::SDK->capture_exception($exception);
+      my $context = { level => Sentry::Severity->Warning };
+      Sentry::SDK->capture_exception($exception, $context);
 
       my $captured = $client->_captured_message;
       isa_ok $captured->{scope}, 'Sentry::Hub::Scope';
       is_deeply $captured->{exception}, $exception;
       is_deeply $captured->{hint}{original_exception} => $exception;
+      is_deeply $captured->{hint}{capture_context}, $context;
       is_UUID_string $captured->{hint}{event_id};
     };
   };


### PR DESCRIPTION
Wrap the `capture_context` parameter in the SDK for what the Client expects. `capture_message` was already written this way, however `capture_exception` and `capture_event` did not correctly wrap the parameter, so the data was lost