### PR TITLE
Fix set_extras so that it does not crash

### DIFF
--- a/lib/Sentry/Hub/Scope.pm
+++ b/lib/Sentry/Hub/Scope.pm
@@ -34,7 +34,9 @@ sub set_extra ($self, $name, $value) {
 }
 
 sub set_extras ($self, $extras) {
-  $self->extra = { %{ $self->extra }, %{$extras} };
+  for my $key (%$extras) {
+    $self->extra->{$key} = $extras->{$key};
+  }
 }
 
 sub set_tag ($self, $key, $value) {

--- a/t/scope.t
+++ b/t/scope.t
@@ -12,6 +12,7 @@ use Sentry::Hub::Scope;
 use Sentry::Severity;
 use Sentry::Tracing::Span;
 use Sentry::Tracing::Transaction;
+use Test::Exception;
 use Test::Spec;
 
 describe 'Sentry::Hub::Scope' => sub {
@@ -79,6 +80,12 @@ describe 'Sentry::Hub::Scope' => sub {
         = $scope->apply_to_event({ level => Sentry::Severity->Fatal });
 
       is $event->{foo}, 'bar';
+    };
+  };
+
+  describe 'set_extras' => sub {
+    it 'set_extras should not crash' => sub {
+      lives_ok { Sentry::Hub::Scope->new->set_extras({ foo => 'bar' }) };
     };
   };
 };


### PR DESCRIPTION
This patch assumes that set_extras is supposed to merely add multiple things to "extra" instead of overwriting the entire "extra" hash. Unclear if this is the correct thing to do or not.

Fixes #20