### PR TITLE
Limit the size of breadcrumb trail

### DIFF
--- a/lib/Sentry/Hub/Scope.pm
+++ b/lib/Sentry/Hub/Scope.pm
@@ -92,7 +92,12 @@ sub clear ($self) {
 
 sub add_breadcrumb ($self, $breadcrumb) {
   $breadcrumb->{timestamp} //= time;
-  push @{ $self->breadcrumbs }, $breadcrumb;
+  my $breadcrumbs = $self->breadcrumbs;
+  # Limit the number of breadcrumbs that we keep
+  if (scalar @$breadcrumbs >= ($ENV{SENTRY_SDK_MAX_BREADCRUMBS} || 100)) {
+    shift @$breadcrumbs;
+  }
+  push @$breadcrumbs, $breadcrumb;
 }
 
 sub clear_breadcrumbs ($self) {


### PR DESCRIPTION
Keep breadcrumbs per scope to 100 (configurable via `SENTRY_SDK_MAX_BREADCRUMBS` environment var).

as suggested in #18 