### PR TITLE
Level from scope overrides level in event

### DIFF
--- a/lib/Sentry/Hub.pm
+++ b/lib/Sentry/Hub.pm
@@ -83,9 +83,10 @@ sub _new_event_id ($self) {
 
 sub capture_message (
   $self, $message,
-  $level = Sentry::Severity->Info,
+  $level = undef,
   $hint = undef,
 ) {
+  $level //= Sentry::Severity->Info;
   my $event_id = $self->_new_event_id();
 
   $self->_invoke_client('capture_message', $message, $level,

--- a/lib/Sentry/Hub/Scope.pm
+++ b/lib/Sentry/Hub/Scope.pm
@@ -14,7 +14,7 @@ has error_event_processors => sub { [] };
 has event_processors       => sub { [] };
 has extra                  => sub { {} };
 has fingerprint            => sub { [] };
-has level                  => Sentry::Severity->Info;
+has level                  => undef;
 has span                   => undef;
 has tags                   => sub { {} };
 has transaction_name       => undef;
@@ -121,7 +121,7 @@ sub apply_to_event ($self, $event, $hint = undef) {
   merge($event, $self, 'user')     if $self->user;
   merge($event, $self, 'contexts') if $self->contexts;
 
-  $event->{level} //= $self->level                if $self->level;
+  $event->{level} = $self->level                  if $self->level;
   $event->{transaction} = $self->transaction_name if $self->transaction_name;
 
   if ($self->span) {

--- a/t/scope.t
+++ b/t/scope.t
@@ -40,17 +40,18 @@ describe 'Sentry::Hub::Scope' => sub {
     };
 
     describe 'level' => sub {
-      it 'defaults to level "info"' => sub {
+      it 'has no default level' => sub {
         my $event = $scope->apply_to_event({});
 
-        is $event->{level}, Sentry::Severity->Info;
+        is $event->{level}, undef;
       };
 
-      it 'does not override the event level' => sub {
+      it 'overrides the event level' => sub {
+        $scope->set_level(Sentry::Severity->Warning);
         my $event
           = $scope->apply_to_event({ level => Sentry::Severity->Fatal });
 
-        is $event->{level}, Sentry::Severity->Fatal;
+        is $event->{level}, Sentry::Severity->Warning;
       };
     };
   };


### PR DESCRIPTION
From https://develop.sentry.dev/sdk/unified-api/:

"scope: A scope holds data that should implicitly be sent with Sentry events. It can hold context data, extra parameters, level overrides, fingerprints etc."

"scope.set_level(level): Sets the level of all events sent within this scope."