### PR TITLE
fix: allow `default_integrations` to actually turn off the defaults

### DIFF
--- a/lib/Sentry/Client.pm
+++ b/lib/Sentry/Client.pm
@@ -23,7 +23,7 @@ has scope        => sub { Sentry::Hub::Scope->new };
 has integrations => sub ($self) { $self->_options->{integrations} // [] };
 
 sub setup_integrations ($self) {
-  Sentry::Integration->setup($self->integrations);
+  Sentry::Integration->setup($self->integrations, $self->_options->{default_integrations} // 1)
 }
 
 #  (alternatively normal constructor) This takes typically an object with options + dsn.

--- a/lib/Sentry/Integration.pm
+++ b/lib/Sentry/Integration.pm
@@ -9,16 +9,18 @@ use Sentry::Integration::MojoUserAgent;
 use Sentry::Integration::MojoTemplate;
 use Sentry::Integration::LwpUserAgent;
 
-my @Global_integrations = (
-  Sentry::Integration::DieHandler->new,
-  Sentry::Integration::DBI->new,
-  Sentry::Integration::MojoUserAgent->new,
-  Sentry::Integration::MojoTemplate->new,
-  Sentry::Integration::LwpUserAgent->new,
-);
+sub default_integrations {
+  return (
+    Sentry::Integration::DieHandler->new,
+    Sentry::Integration::DBI->new,
+    Sentry::Integration::MojoUserAgent->new,
+    Sentry::Integration::MojoTemplate->new,
+    Sentry::Integration::LwpUserAgent->new,
+  );
+}
 
-sub setup ($package, $custom_integrations = []) {
-  my @all_integrations = (@Global_integrations, $custom_integrations->@*);
+sub setup ($package, $custom_integrations = [], $use_defaults = 1) {
+  my @all_integrations = ($use_defaults ? default_integrations() : (), $custom_integrations->@*);
   foreach my $integration (grep { !$_->initialized } @all_integrations) {
     $integration->setup_once(
       Sentry::Hub::Scope->can('add_global_event_processor'),

--- a/lib/Sentry/SDK.pm
+++ b/lib/Sentry/SDK.pm
@@ -28,7 +28,7 @@ sub _init_and_bind ($options) {
 }
 
 sub init ($package, $options = {}) {
-  $options->{default_integrations} //= [];
+  $options->{default_integrations} //= 1;
   $options->{dsn}                  //= $ENV{SENTRY_DSN};
   $options->{traces_sample_rate}   //= $ENV{SENTRY_TRACES_SAMPLE_RATE};
   $options->{release}              //= $ENV{SENTRY_RELEASE};

--- a/t/snapshots/sdk_t/client_options
+++ b/t/snapshots/sdk_t/client_options
@@ -15,7 +15,7 @@
     }
   },
   'debug' => 1,
-  'default_integrations' => [],
+  'default_integrations' => 1,
   'dsn' => 'abc',
   'environment' => 'my env',
   'release' => 'my release',

--- a/t/snapshots/sdk_t/client_options_env_
+++ b/t/snapshots/sdk_t/client_options_env_
@@ -14,7 +14,7 @@
       }, 'version' )
     }
   },
-  'default_integrations' => [],
+  'default_integrations' => 1,
   'dsn' => 'DSN from env',
   'environment' => 'environment from env',
   'release' => 'release from env',


### PR DESCRIPTION
  * in addition, we provide the defaults as a sub in case the user wants
    to manually add them (delaying initialization could make a difference)


If there's anything you'd want changed in the implementation, i'm happy to do so. I
personally need this b/c I used to get memory leaks from spans very early in my mojo app,
so i had to patch the code locally to turn off storing any breadcrumbs outside of the
req/res cycle.

In any case, the docs claim that you can turn off the default integrations, and before
this patch that is not the case.

I also changed the default value for `default_integrations` to 1 rather than empty array
b/c it's not meant to be an array
