### PR TITLE
Decode source files as UTF-8

### DIFF
--- a/lib/Sentry/SourceFileRegistry.pm
+++ b/lib/Sentry/SourceFileRegistry.pm
@@ -1,6 +1,7 @@
 package Sentry::SourceFileRegistry;
 use Mojo::Base -base, -signatures;
 
+use Encode;
 use Mojo::File;
 use Mojo::Util 'dumper';
 use Sentry::Cache;
@@ -11,6 +12,7 @@ has _cache => sub { Sentry::Cache->get_instance };
 sub _get_cached_context_line ($self, $file) {
   if (!$self->_cache->exists($file)) {
     my $content = -e $file ? Mojo::File->new($file)->slurp : undef;
+    $content = Encode::decode('UTF-8', $content, Encode::FB_DEFAULT) if $content;
 
     my $context
       = Sentry::SourceFileRegistry::ContextLine->new(content => $content);

--- a/t/data/source-file-cp1252.pl
+++ b/t/data/source-file-cp1252.pl
@@ -1,0 +1,1 @@
+print "this file contains cp1252: €\n";

--- a/t/data/source-file-utf8.pl
+++ b/t/data/source-file-utf8.pl
@@ -1,0 +1,2 @@
+use utf8;
+print "this file contains valid utf8 content: 🦄\n";

--- a/t/sourcefileregistry.t
+++ b/t/sourcefileregistry.t
@@ -1,0 +1,41 @@
+use Mojo::Base -strict, -signatures;
+
+use utf8;
+
+use Mojo::File;
+# curfile missing in Mojolicious@^8. The dependency shall not be updated for
+# the time being. For this reason `curfile` is duplicated for now.
+# use lib curfile->sibling('lib')->to_string;
+# See https://github.com/mojolicious/mojo/blob/4093223cae00eb516e38f2226749d2963597cca3/lib/Mojo/File.pm#L36
+use lib Mojo::File->new(Cwd::realpath((caller)[1]))->sibling('lib')->to_string;
+
+use Mojo::Exception;
+use Mojo::Home;
+use Mojo::JSON;
+use Sentry::Stacktrace;
+use Sentry::Stacktrace::Frame;
+use Mock::Sentry::SourceFileRegistry;
+use Test::Exception;
+use Test::Spec;
+
+{
+
+  package My::Exception;
+  use Mojo::Base -base;
+}
+
+describe 'Sentry::SourceFileRegistry' => sub {
+  it 'decodes source file as utf8' => sub {
+    my $reg = Sentry::SourceFileRegistry->new;
+    my $context = $reg->get_context_lines('t/data/source-file-utf8.pl', 2);
+    is $context->{context_line}, 'print "this file contains valid utf8 content: 🦄\n";'
+  };
+
+  it 'handles non-utf-8 source files' => sub {
+    my $reg = Sentry::SourceFileRegistry->new;
+    my $context = $reg->get_context_lines('t/data/source-file-cp1252.pl', 1);
+    is $context->{context_line}, qq{print "this file contains cp1252: \x{fffd}\\n";};
+  };
+};
+
+runtests;


### PR DESCRIPTION
If the file contains invalid UTF-8 replace the invalid bytes with the replacement character.